### PR TITLE
Catch warnings, change params argument

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -36,7 +36,7 @@ solve!(p, SDPAFamily.Optimizer())
 ```
 Applying presolve helps by removing 8 redundant constraints from the final input file.
 ```@repl convexquantum
-opt.presolve = true; opt.silent = true;
+opt.presolve = true; opt.verbosity = SDPAFamily.SILENT;
 solve!(p, opt)
 @test p.optval ≈ (6 - sqrt(big"2.0"))/4 atol=1e-30
 SDPAFamily.presolve(opt)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -3,10 +3,11 @@
 The main object of interest supplied by this package is `SDPAFamily.Optimizer{T}()`. Here, `T` is a numeric type which defaults to `BigFloat`. Keyword arguments may also be passed to `SDPAFamily.Optimizer()`:
 
 * `variant`: either `:sdpa_gmp`, `:sdpa_qd`, or `:sdpa_dd`, to use SDPA-GMP, SDPA-QD, or SDPA-DD, respectively. Defaults to `:sdpa_gmp`.
-* `silent`: a boolean to indicate whether or not to print output. Defaults to `true`.
+* `silent`: a boolean to indicate whether or not to print output. Defaults to `false`.
+* `verbose`: accepts either `SDPAFamily.SILENT` (which is equivalent to `silent=true`), `SDPAFamily.WARN` (which is the default), or `SDPAFamily.VERBOSE`, which prints all output from the binary as well as additional warnings.
 * `presolve`: whether or not to run a presolve routine to remove linearly dependent constraints. See below for more details. Defaults to `false`. Note, `presolve=true` is required to pass many of the tests for this package; linearly independent constraints are an assumption of the SDPA-family, but constraints generated from high level modelling languages often do have linear dependence between them.
 * `binary_path`: a string representing a path to the SDPA-GMP binary to use. The default is chosen at `build` time. To change the default binaries, see [Custom binary](@ref).
-* `params_path`: a string representing a path to a parameter file named `param.sdpa` in the same folder as the binary if present. The default parameters used by `SDPAFamily.jl` are listed [here](https://github.com/ericphanson/SDPAFamily.jl/blob/master/deps/). There are two other sets of parameters, `UNSTABLE_BUT_FAST` and `STABLE_BUT_SLOW`, called by `params_path = "-pt 1"` and `params_path = "-pt 2"` respectively. For details please refer to the [SDPA users manual](https://sourceforge.net/projects/sdpa/files/sdpa/sdpa.7.1.1.manual.20080618.pdf).
+* `params`: either `SDPAFamily.DEFAULT` (the default option), `SDPAFamily.UNSTABLE_BUT_FAST`, `SDPAFamily.STABLE_BUT_SLOW`, or a string representing a path to a parameter file. The default parameters used by `SDPAFamily.jl` are listed [here](https://github.com/ericphanson/SDPAFamily.jl/blob/master/deps/). There are two other choices of parameters, `UNSTABLE_BUT_FAST` and `STABLE_BUT_SLOW` are documented in the [SDPA users manual](https://sourceforge.net/projects/sdpa/files/sdpa/sdpa.7.1.1.manual.20080618.pdf).
 
 `SDPAFamily.Optimizer()` also accepts `variant = :sdpa` to use the non-high-precision SDPA binary. For general usage of the SDPA solver, use [SDPA.jl](https://github.com/JuliaOpt/SDPA.jl) which uses the C++ library to interface directly with the SDPA binary.
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -90,14 +90,14 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
             throw(ArgumentError("Cannot set both `silent=true` and `verbose != SILENT`."))
         end
 
-		if T != BigFloat && optimizer.verbosity != SILENT
+		if T != BigFloat && optimizer.verbosity == VERBOSE
 			@warn "Not using BigFloat entries may cause underflow errors."
         end
 
 		if params_path == (use_WSL ? WSLize_path(default_params_path[variant]) : default_params_path[variant]) && optimizer.variant == :sdpa_gmp && T != BigFloat
             optimizer.params_path = use_WSL ? WSLize_path(default_params_path[:sdpa_gmp_float64]) : default_params_path[:sdpa_gmp_float64]
             
-			if optimizer.verbosity == SILENT
+			if optimizer.verbosity == VERBOSE
 				@info "Precision reduced to 80 bits on problems with Float64 entries."
 			end
 		end

--- a/src/SDPAFamily.jl
+++ b/src/SDPAFamily.jl
@@ -6,6 +6,12 @@ const MOI = MathOptInterface
 const MOIB = MOI.Bridges
 using BinaryProvider
 
+"""
+Set the verbosity level of an `SDPAFamily.Optimizer`.
+
+Options are `SILENT`, `WARN`, or `VERBOSE`.
+"""
+@enum Verbosity SILENT WARN VERBOSE
 
 # The `deps.jl` file defines `HAS_WSL::Bool` and `sdpa_gmp::String`.
 #

--- a/src/SDPAFamily.jl
+++ b/src/SDPAFamily.jl
@@ -7,11 +7,21 @@ const MOIB = MOI.Bridges
 using BinaryProvider
 
 """
-Set the verbosity level of an `SDPAFamily.Optimizer`.
+Possible verbosity levels of an `SDPAFamily.Optimizer`.
 
 Options are `SILENT`, `WARN`, or `VERBOSE`.
 """
 @enum Verbosity SILENT WARN VERBOSE
+
+"""
+Possible the parameter settings of an `SDPAFamily.Optimizer`.
+One can also pass a path to the `params` keyword argument to use
+a custom parameter file.
+
+Options are `DEFAULT`, `UNSTABLE_BUT_FAST`, or `STABLE_BUT_SLOW`.
+"""
+@enum ParamsSetting DEFAULT UNSTABLE_BUT_FAST STABLE_BUT_SLOW
+
 
 # The `deps.jl` file defines `HAS_WSL::Bool` and `sdpa_gmp::String`.
 #

--- a/src/binary_call.jl
+++ b/src/binary_call.jl
@@ -11,7 +11,7 @@ function sdpa_gmp_binary_solve!(m::Optimizer, full_input_path::String, full_outp
     if m.use_WSL
         full_input_path = WSLize_path(full_input_path)
         full_output_path = WSLize_path(full_output_path)
-        if !m.silent
+        if !m.verbosity != SILENT
             @info "Redirecting to WSL environment."
         end
     end
@@ -22,14 +22,81 @@ function sdpa_gmp_binary_solve!(m::Optimizer, full_input_path::String, full_outp
     end
     if m.use_WSL
         wsl_binary_path = dirname(normpath(m.binary_path))
-        cd(wsl_binary_path) do
+        error_messages, miss = cd(wsl_binary_path) do
             var = string(m.variant)
-            run(pipeline(`wsl ./$var $arg`, stdout = m.silent ? devnull : stdout))
+            run_binary(`wsl ./$var $arg`, m.verbosity)
         end
     else
-        withenv([prefix]) do
-            run(pipeline(`$(m.binary_path) $arg`, stdout = m.silent ? devnull : stdout))
+        error_messages, miss = withenv([prefix]) do
+            run_binary(`$(m.binary_path) $arg`, m.verbosity)
         end
     end
+
+    error_log_path = joinpath(m.tempdir, "errors.log")
+    open(error_log_path, "w") do io
+        print(io, error_messages)
+    end
+
+    if m.verbosity != SILENT
+        if m.verbosity == VERBOSE && error_messages != ""
+            println("error log: $error_log_path") 
+        end
+
+        if miss
+            @warn("'cholesky miss condition' warning detected; results may be unreliable. Try `presolve=true`, or see troubleshooting guide.")
+        end
+    end
+
     read_results!(m, read_path, redundant_entries);
+end
+
+
+function run_binary(cmd::Cmd, verbosity)
+    if verbosity == SILENT
+        error_messages, miss = run_and_parse_output(devnull, devnull, cmd)
+    elseif verbosity == WARN
+        error_messages, miss = run_and_parse_output(stdout, stderr, cmd)
+    else
+        error_messages, miss = run_and_parse_output(stdout, stderr, cmd; echo = true)
+    end
+
+    return error_messages, miss
+end
+
+
+function run_and_parse_output(out_io, err_io, cmd; echo = false)
+    buffer = IOBuffer()
+    miss = false
+    function print_stream(out)
+        for line in eachline(out)
+            if occursin(" :: ", line)
+                if occursin("cholesky miss condition", line)
+                    miss=true
+                end
+                println(out_io, "Warning: $line")
+                println(buffer, "Warning: $line")
+            elseif echo
+                println(out_io, line)
+            end
+        end
+    end
+
+    function error_stream(out)
+        for line in eachline(out)
+            println(err_io, "error: $line")
+            write(buffer, "error: $line")
+        end
+    end
+
+    out = Pipe()
+    err = Pipe()
+    process = run(pipeline(cmd, stdout=out, stderr=err), wait=false)
+    close(out.in)
+    close(err.in)
+
+
+    s1 = @async print_stream(out)
+    s2 = @async error_stream(err)
+    wait.((process, s1, s2))
+    return String(take!(buffer)), miss
 end

--- a/src/file_io.jl
+++ b/src/file_io.jl
@@ -87,7 +87,7 @@ function read_results!(
                 line = getnextline(io)
             end
         end
-    if norm(optimizer.b, Inf) < eps(norm(xMatvec, Inf)) || norm(optimizer.b, Inf) < eps(norm(yMatvec, Inf))
+    if optimizer.verbosity != SILENT && (norm(optimizer.b, Inf) < eps(norm(xMatvec, Inf)) || norm(optimizer.b, Inf) < eps(norm(yMatvec, Inf)))
         @warn "Potential underflow detected. Check the results and use `BigFloat` entries if necessary."
     end
     xVecstring = remove_brackets!(xVecstring)

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -31,7 +31,9 @@ function presolve(optimizer::SDPAFamily.Optimizer{T}) where T
         if aug_mat[i, end] != 0
             # println(aug_mat[i, end])
             abort = 1
-            @warn "Inconsistency at constraint index $i. Problem is dual infeasible."
+            if optimizer.verbosity != SILENT
+                @warn "Inconsistency at constraint index $i. Problem is dual infeasible."
+            end
         end
     end
     if abort == 1

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -50,7 +50,7 @@ function presolve(optimizer::SDPAFamily.Optimizer{T}) where T
     end
     finish = time() - start
     n = length(redundant_F)
-    if optimizer.verbosity != SILENT
+    if optimizer.verbosity == VERBOSE
         @info "Presolve finished in $finish seconds. $n constraint(s) eliminated."
     end
     return sort!(redundant_F)

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -48,7 +48,7 @@ function presolve(optimizer::SDPAFamily.Optimizer{T}) where T
     end
     finish = time() - start
     n = length(redundant_F)
-    if !optimizer.silent
+    if optimizer.verbosity != SILENT
         @info "Presolve finished in $finish seconds. $n constraint(s) eliminated."
     end
     return sort!(redundant_F)

--- a/test/Convex.jl
+++ b/test/Convex.jl
@@ -46,42 +46,45 @@ const no_presolve_problems = ["affine_Partial_transpose", "lp_min_atom", "lp_max
 # Some problems need a different choice of parameters to pass the tests
 const params_options = Dict(
                     (:sdpa_gmp, Float64) => Dict(
-                            "affine_Partial_transpose" => "-pt 1",
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
+                        ),
+                    (:sdpa_gmp, Double64) => Dict(
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
                         ),
                     (:sdpa_dd, Float64) =>  Dict(
-                            "lp_dotsort_atom" => "-pt 1",
-                            "lp_pos_atom" => "-pt 1",
-                            "lp_neg_atom" => "-pt 1",
-                            "sdp_matrix_frac_atom" => "-pt 1",
-                            "affine_Partial_transpose" => "-pt 1",
+                            "lp_dotsort_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "lp_pos_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "lp_neg_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "sdp_matrix_frac_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
                         ),
                     (:sdpa_dd, BigFloat) =>  Dict(
-                        "lp_dotsort_atom" => "-pt 1",
-                        "lp_pos_atom" => "-pt 1",
-                        "lp_neg_atom" => "-pt 1",
-                        "sdp_matrix_frac_atom" => "-pt 1",
-                        "affine_Partial_transpose" => "-pt 1",
-                        "affine_Diagonal_atom" => "-pt 1",
+                        "lp_dotsort_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                        "lp_pos_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                        "lp_neg_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                        "sdp_matrix_frac_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                        "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
+                        "affine_Diagonal_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
                         ),
                     (:sdpa_dd, Double64) =>  Dict(
-                            "lp_dotsort_atom" => "-pt 1",
-                            "lp_pos_atom" => "-pt 1",
-                            "lp_neg_atom" => "-pt 1",
-                            "sdp_matrix_frac_atom" => "-pt 1",
-                            "affine_Partial_transpose" => "-pt 1",
-                            "affine_Diagonal_atom" => "-pt 1",
+                            "lp_dotsort_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "lp_pos_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "lp_neg_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "sdp_matrix_frac_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "affine_Diagonal_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
                             ),
                     (:sdpa_qd, Float64) =>  Dict(
-                            "affine_Partial_transpose" => "-pt 1",
-                            "affine_Diagonal_atom" => "-pt 1",
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "affine_Diagonal_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
                         ),
                     (:sdpa_qd, BigFloat) =>  Dict(
-                            "affine_Partial_transpose" => "-pt 1",
-                            "affine_Diagonal_atom" => "-pt 1",
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "affine_Diagonal_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
                         ),
                     (:sdpa_qd, Double64) =>  Dict(
-                            "affine_Partial_transpose" => "-pt 1",
-                            "affine_Diagonal_atom" => "-pt 1",
+                            "affine_Partial_transpose" => SDPAFamily.UNSTABLE_BUT_FAST,
+                            "affine_Diagonal_atom" => SDPAFamily.UNSTABLE_BUT_FAST,
                         ))
 @testset "Convex tests" for var in variants
     @testset "Convex tests with variant $var and type $T" for T in (Float64, Double64, BigFloat)
@@ -95,7 +98,7 @@ const params_options = Dict(
 
                     params = get(get(params_options, (var, T), Dict()), name, nothing)
                     if params !== nothing
-                        settings = (params_path = params, settings...)
+                        settings = (params = params, settings...)
                     end
 
                     Convex.solve!(p, SDPAFamily.Optimizer{T}(; settings...))

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -16,7 +16,7 @@ import SDPAFamily
     MOI.set(optimizer, MOI.Silent(), true)
 
     @testset "SolverName" begin
-        @test MOI.get(optimizer, MOI.SolverName()) == "SDPA-GMP"
+        @test MOI.get(optimizer, MOI.SolverName()) == "SDPAFamily"
     end
 
     @testset "supports_default_copy_to" begin

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -8,65 +8,67 @@ const MOIB = MOI.Bridges
 
 import SDPAFamily
 
-@testset "MOI tests with type T=$T" for T in (
-                                                Float64,
-                                                # BigFloat # not yet supported: MathOptInterface#41
-                                            )
-    optimizer = SDPAFamily.Optimizer{T}(presolve=true, variant = var)
-    MOI.set(optimizer, MOI.Silent(), true)
+@testset "MOI tests" for var in variants
+    @testset "MOI tests with variant $var and type T=$T" for T in (
+                                                    Float64,
+                                                    # BigFloat # not yet supported: MathOptInterface#41
+                                                )
+        optimizer = SDPAFamily.Optimizer{T}(presolve=true, variant = var)
+        MOI.set(optimizer, MOI.Silent(), true)
 
-    @testset "SolverName" begin
-        @test MOI.get(optimizer, MOI.SolverName()) == "SDPAFamily"
-    end
+        @testset "SolverName" begin
+            @test MOI.get(optimizer, MOI.SolverName()) == "SDPAFamily"
+        end
 
-    @testset "supports_default_copy_to" begin
-        @test MOIU.supports_allocate_load(optimizer, false)
-        @test !MOIU.supports_allocate_load(optimizer, true)
-    end
+        @testset "supports_default_copy_to" begin
+            @test MOIU.supports_allocate_load(optimizer, false)
+            @test !MOIU.supports_allocate_load(optimizer, true)
+        end
 
-    # UniversalFallback is needed for starting values, even if they are ignored by SDPA
-    cache = MOIU.UniversalFallback(MOIU.Model{T}())
-    cached = MOIU.CachingOptimizer(cache, optimizer)
-    bridged = MOIB.full_bridge_optimizer(cached, T)
-    # test 1e-3 because of rsoc3 test, otherwise, 1e-5 is enough
-    config = MOIT.TestConfig(atol=1e-3, rtol=1e-3)
+        # UniversalFallback is needed for starting values, even if they are ignored by SDPA
+        cache = MOIU.UniversalFallback(MOIU.Model{T}())
+        cached = MOIU.CachingOptimizer(cache, optimizer)
+        bridged = MOIB.full_bridge_optimizer(cached, T)
+        # test 1e-3 because of rsoc3 test, otherwise, 1e-5 is enough
+        config = MOIT.TestConfig(atol=1e-3, rtol=1e-3)
 
-    @testset "Unit" begin
-        exclusion_list = [
-            # `TimeLimitSec` not supported.
-            "time_limit_sec",
-            # SingleVariable objective of bridged variables, will be solved by objective bridges
-            "solve_time", "raw_status_string",
-            "solve_singlevariable_obj",
-            # Quadratic functions are not supported
-            "solve_qcp_edge_cases", "solve_qp_edge_cases",
-            # Integer and ZeroOne sets are not supported
-            "solve_integer_edge_cases", "solve_objbound_edge_cases",
-            "solve_zero_one_with_bounds_1",
-            "solve_zero_one_with_bounds_2",
-            "solve_zero_one_with_bounds_3",
-            # Underflow results when using Float64
-            "solve_affine_equalto"]
-        MOIT.unittest(bridged, config, exclusion_list)
-    end
-    @testset "Linear tests" begin
-        # See explanation in `MOI/test/Bridges/lazy_bridge_optimizer.jl`.
-        # This is to avoid `Variable.VectorizeBridge` which does not support
-        # `ConstraintSet` modification.
-        MOIB.remove_bridge(bridged, MOIB.Constraint.ScalarSlackBridge{T})
-        MOIT.contlineartest(bridged, config, [
-            # `MOI.UNKNOWN_RESULT_STATUS` instead of `MOI.INFEASIBILITY_CERTIFICATE`
-            "linear8a",
-            "linear12"
-        ])
-    end
-    @testset "Conic tests" begin
-        MOIT.contconictest(bridged, config, [
-            # `MOI.UNKNOWN_RESULT_STATUS` instead of `MOI.INFEASIBILITY_CERTIFICATE`
-            "lin3", "soc3", "norminf2", "normone2",
-            # Missing bridges
-            "rootdets",
-            # Does not support power and exponential cone
-            "pow", "logdet", "exp"])
+        @testset "Unit" begin
+            exclusion_list = [
+                # `TimeLimitSec` not supported.
+                "time_limit_sec",
+                # SingleVariable objective of bridged variables, will be solved by objective bridges
+                "solve_time", "raw_status_string",
+                "solve_singlevariable_obj",
+                # Quadratic functions are not supported
+                "solve_qcp_edge_cases", "solve_qp_edge_cases",
+                # Integer and ZeroOne sets are not supported
+                "solve_integer_edge_cases", "solve_objbound_edge_cases",
+                "solve_zero_one_with_bounds_1",
+                "solve_zero_one_with_bounds_2",
+                "solve_zero_one_with_bounds_3",
+                # Underflow results when using Float64
+                "solve_affine_equalto"]
+            MOIT.unittest(bridged, config, exclusion_list)
+        end
+        @testset "Linear tests" begin
+            # See explanation in `MOI/test/Bridges/lazy_bridge_optimizer.jl`.
+            # This is to avoid `Variable.VectorizeBridge` which does not support
+            # `ConstraintSet` modification.
+            MOIB.remove_bridge(bridged, MOIB.Constraint.ScalarSlackBridge{T})
+            MOIT.contlineartest(bridged, config, [
+                # `MOI.UNKNOWN_RESULT_STATUS` instead of `MOI.INFEASIBILITY_CERTIFICATE`
+                "linear8a",
+                "linear12"
+            ])
+        end
+        @testset "Conic tests" begin
+            MOIT.contconictest(bridged, config, [
+                # `MOI.UNKNOWN_RESULT_STATUS` instead of `MOI.INFEASIBILITY_CERTIFICATE`
+                "lin3", "soc3", "norminf2", "normone2",
+                # Missing bridges
+                "rootdets",
+                # Does not support power and exponential cone
+                "pow", "logdet", "exp"])
+        end
     end
 end

--- a/test/custom_param/custom.jl
+++ b/test/custom_param/custom.jl
@@ -1,0 +1,14 @@
+using Test, SDPAFamily
+using Convex, LinearAlgebra
+
+params_file = joinpath(@__DIR__, "custom_params.sdpa")
+setprecision(800) do
+    E12, E21 = ComplexVariable(2, 2), ComplexVariable(2, 2)
+    s1, s2 = [big"0.25" big"-0.25"*im; big"0.25"*im big"0.25"], [big"0.5" big"0.0"; big"0.0" big"0.0"]
+    p = Problem{BigFloat}(:minimize, real(tr(E12 * (s1 + 2 * s2) + E21 * (s2 + 2 * s1))), [E12 ⪰ 0, E21 ⪰ 0, E12 + E21 == Diagonal(ones(2)) ])
+    opt = SDPAFamily.Optimizer(params = params_file, presolve = true, variant = :sdpa_gmp)
+    time = @elapsed solve!(p, opt)
+
+    correct_val =  (6 - sqrt(big"2.0"))/4
+    @test p.optval ≈ correct_val atol=1e-80
+end

--- a/test/custom_param/custom_params.sdpa
+++ b/test/custom_param/custom_params.sdpa
@@ -1,0 +1,15 @@
+1600	unsigned int maxIteration;
+1.0E-90	double 0.0 < epsilonStar;
+1.0E4   double 0.0 < lambdaStar;
+2.0   	double 1.0 < omegaStar;
+-1.0E5  double lowerBound;
+1.0E5   double upperBound;
+0.1     double 0.0 <= betaStar <  1.0;
+0.3     double 0.0 <= betaBar  <  1.0, betaStar <= betaBar;
+0.9     double 0.0 < gammaStar  <  1.0;
+1.0E-90	double 0.0 < epsilonDash;
+800     precision
+%+.Fe     char*  xPrint   (default %+8.3e,   NOPRINT skips printout)
+%+.Fe     char*  XPrint   (default %+8.3e,   NOPRINT skips printout)
+%+.Fe     char*  YPrint   (default %+8.3e,   NOPRINT skips printout)
+%+.Fe     char*  infPrint (default %+10.16e, NOPRINT skips printout)

--- a/test/presolve.jl
+++ b/test/presolve.jl
@@ -87,7 +87,7 @@ end
     end
 
     @testset "inconsistent constraints" begin
-        m = SDPAFamily.Optimizer(silent = true)
+        m = SDPAFamily.Optimizer(verbose = SDPAFamily.WARN)
         m.blockdims = [3]
         m.elemdata = [(1, 1, 1, 1, big"1.0"), (1, 1, 2, 2, big"1.0"), (1, 1, 3, 3, big"1.0"),
             (2, 1, 1, 2, big"2.0"), (2, 1, 2, 1, big"2.0"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Test
 using Pkg
 Pkg.add(PackageSpec(name="Convex", url="https://github.com/ericphanson/Convex.jl", rev="MathOptInterface"))
 
+const variants = (:sdpa, :sdpa_dd, :sdpa_qd, :sdpa_gmp)
+
 @testset "SDPAFamily" begin
 
     @testset "General utilities" begin
@@ -12,29 +14,9 @@ Pkg.add(PackageSpec(name="Convex", url="https://github.com/ericphanson/Convex.jl
         include("variant_test.jl")
     end
 
-    @testset "SDPA-plain" begin
-        global var = :sdpa
-        include("MOI_wrapper.jl")
-        include("Convex.jl")
-    end
+    include("Convex.jl")
 
-    @testset "SDPA-DD" begin
-        global var = :sdpa_dd
-        include("MOI_wrapper.jl")
-        include("Convex.jl")
-    end
-
-    @testset "SDPA-QD" begin
-        global var = :sdpa_qd
-        include("MOI_wrapper.jl")
-        include("Convex.jl")
-    end
-
-    @testset "SDPA-GMP" begin
-        global var = :sdpa_gmp
-        include("MOI_wrapper.jl")
-        include("Convex.jl")
-    end
+    include("MOI_wrapper.jl")
 
     @testset "High-precision example" begin
         include("high_precision_test.jl")


### PR DESCRIPTION
Closes https://github.com/ericphanson/SDPAFamily.jl/issues/13

Now the default verbosity is WARN, which ideally doesn't emit anything on most problems, but warns if there are possible issues. The goal is to avoid users setting `silent=true` out of annoyance from us printing too much and then missing helpful warnings.

I also updated the `params` so one can pass e.g. `SDPAFamily.UNSTABLE_BUT_FAST` as an argument.