### PR TITLE
Fix `OPTIMIZE_NOT_CALLED`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ const variants = (:sdpa, :sdpa_dd, :sdpa_qd, :sdpa_gmp)
 
     @testset "General utilities" begin
         include("presolve.jl")
+        include("status_test.jl")
         include("variant_test.jl")
     end
 

--- a/test/status_test.jl
+++ b/test/status_test.jl
@@ -1,0 +1,12 @@
+using Convex, SDPAFamily, Test, MathOptInterface
+const MOI = MathOptInterface
+
+
+problem_func = Convex.ProblemDepot.PROBLEMS["lp"]["lp_dotsort_atom"];
+problem_func(Val(true), 1e-3, 0.0, BigFloat) do p
+    opt = SDPAFamily.Optimizer{}(; 
+    params = SDPAFamily.UNSTABLE_BUT_FAST,
+    presolve = false, variant = :sdpa_dd)
+    Convex.solve!(p, opt)
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.ITERATION_LIMIT
+end


### PR DESCRIPTION
Fixes #19; let's merge if CI passes.

I think we may want easier ways to customize parameters; I know as a user that if I get iteration limits warnings, I'll want to just bump the number of iterations to see if that helps. Maybe we can add some keyword arguments to choose some of the parameters and write a custom parameter file based on those (using the defaults for the rest).