### PR TITLE
Update tests

### DIFF
--- a/test/Convex.jl
+++ b/test/Convex.jl
@@ -14,14 +14,8 @@ const common_excludes = Regex[
 # Problems that cannot be handled due to issues with a certain numeric type,
 # independent of variant.
 const type_excludes = Dict( Float64 => Regex[],
-                            BigFloat => Regex[
-                                r"sdp_lambda_max_atom", # GenericLinearAlgebra#47
-                                r"socp", # MathOptInterface.jl#876
-                        ],
-                        Double64 => Regex[
-                                r"sdp_lambda_max_atom", # GenericLinearAlgebra#47
-                                r"socp", # MathOptInterface.jl#876
-                        ])
+                            BigFloat => Regex[],
+                            Double64 => Regex[])
 
 # Problems that cannot be handled with a specific combination of variant and numeric type
 # (often due to things like underflow).

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -67,8 +67,8 @@ import SDPAFamily
                 "lin3", "soc3", "norminf2", "normone2",
                 # Missing bridges
                 "rootdets",
-                # Does not support power and exponential cone
-                "pow", "logdet", "exp"])
+                # Does not support power and exponential cone, or their dual cones
+                "pow", "dualpow", "logdet", "exp", "dualexp" ])
         end
     end
 end


### PR DESCRIPTION
Closes #24 

The additional MOI exclusions are just because we don't support the cones that they are testing.