### PR TITLE
Add TemporyDirectory attribute

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -183,7 +183,7 @@ However, the following path is always printed when setting `verbose =
 SDPAFamily.VERBOSE`.
 
 ```@repl sumofsquares
-path = joinpath(model.moi_backend.optimizer.model.optimizer.tempdir, "input.dat-s")
+path = joinpath(MOI.get(model, SDPAFamily.TemporaryDirectory()),  "input.dat-s")
 readlines(path)[1:10] .|> println;
 ```
 

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -1,0 +1,21 @@
+@testset "TemporaryDirectory" begin
+
+    optimizer = SDPAFamily.Optimizer{Float64}()
+    tmp = MOI.get(optimizer, SDPAFamily.TemporaryDirectory())
+    @test tmp == optimizer.tempdir
+    @test isdir(tmp)
+
+    tmp_arg = mktempdir()
+    optimizer = SDPAFamily.Optimizer{Float64}(TemporaryDirectory=tmp_arg)
+    @test tmp_arg == MOI.get(optimizer, SDPAFamily.TemporaryDirectory())
+    
+
+    new_tmp = mktempdir()
+    MOI.set(optimizer, SDPAFamily.TemporaryDirectory(), new_tmp)
+    @test new_tmp == MOI.get(optimizer, SDPAFamily.TemporaryDirectory())
+
+    # check that it survives `empty`
+    MOI.empty!(optimizer)
+    @test new_tmp == MOI.get(optimizer, SDPAFamily.TemporaryDirectory())
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ const variants = (:sdpa, :sdpa_dd, :sdpa_qd, :sdpa_gmp)
         include("presolve.jl")
         include("status_test.jl")
         include("variant_test.jl")
+        include("attributes.jl")
     end
 
     include("Convex.jl")


### PR DESCRIPTION
As suggested by @blegat on Slack. I also changed the code to not choose a new temporary directory on `MOI.empty!` but instead just delete the files we created in the current one. That way if the user specifies a particular temporary directory, the optimizer will continue to use it.