### PR TITLE
Use supports_add_constrained_variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 BinaryProvider = "0.5"
 DoubleFloats = "0.9.9"
-MathOptInterface = "0.9.5"
+MathOptInterface = "0.9.14"
 julia = "1.5"
 
 [extras]

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -207,11 +207,9 @@ function MOI.supports(
     return true
 end
 
-function MOI.supports_constraint(
-    ::Optimizer, ::Type{MOI.VectorOfVariables}, ::Type{MOI.Reals})
-    return false
-end
+MOI.supports_add_constrained_variables(::Optimizer, ::Type{MOI.Reals}) = false
 const SupportedSets = Union{MOI.Nonnegatives, MOI.PositiveSemidefiniteConeTriangle}
+MOI.supports_add_constrained_variables(::Optimizer, ::Type{<:SupportedSets}) = true
 function MOI.supports_constraint(
     ::Optimizer, ::Type{MOI.VectorOfVariables},
     ::Type{<:SupportedSets})


### PR DESCRIPTION
`supports_add_constrained_variables` was introduced in a previous MOI release and it is now required to implement it rather than `supports_constraint` as the `LazyBridgeOptimizer` now assumes that this is implemented by solvers.
This is a breaking change for solvers (not for users). We shouldn't really have included it in a non-breaking MOI release but we've chosen the approach of introducing the new function in an early release to leave the time for solvers to transition. Now is the time as MOI v0.9.15 will start requiring the solvers to have tranitioned.
This PR does the transition.