### PR TITLE
Fix compat of Convex.jl in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "0.5"
+Convex = "0.14"
 DoubleFloats = "0.9.9"
 MathOptInterface = "0.9.14"
 julia = "1.5"


### PR DESCRIPTION
This was causing tests to fail with `MOI#master`.