### PR TITLE
Put temporary directories and dependencies in a scratch space

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SDPA_jll = "7fc90fd6-dbef-5a6a-93f8-169f2a2e705b"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
@@ -17,6 +18,7 @@ BinaryProvider = "0.5"
 Convex = "0.14"
 DoubleFloats = "0.9.9"
 MathOptInterface = "0.9.14"
+Scratch = "1"
 julia = "1.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SDPA_jll = "7fc90fd6-dbef-5a6a-93f8-169f2a2e705b"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 BinaryProvider = "0.5"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ const SDPAFamily_UUID = UUID("bfe18334-aefd-11e9-1109-4bf2b15a5b91")
 # Key off of Julia version to avoid issues like <https://github.com/ericphanson/SDPAFamily.jl/issues/29#issue-549039097>
 # why key off `Sys.KERNEL`? I once had some strange setup with WSL2 where I had windows
 # and linux runtimes looking at the same filesystem. This might help...
-const DEPS_DIR = get_scratch!(SDPAFamily_UUID, string("build_julia_", VERSION, "_", Sys.KERNEL))
+const DEPS_DIR = get_scratch!(SDPAFamily_UUID, string("build_julia_", VERSION.major, ".", VERSION.minor, "_", Sys.KERNEL))
 
 # Parse some basic command-line arguments
 const verbose = "--verbose" in ARGS

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -82,7 +82,7 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
             binary_path = BB_PATHS[variant],
             use_WSL = HAS_WSL[variant],
             params::Union{Params, ParamsSetting, String, NamedTuple} = Params{variant, T}(),
-            TemporaryDirectory::String = mktempdir(),
+            TemporaryDirectory::String = mktempdir(@get_scratch!("solves")),
             ) where T
 
         if params isa NamedTuple

--- a/src/SDPAFamily.jl
+++ b/src/SDPAFamily.jl
@@ -24,7 +24,7 @@ Options are `DEFAULT`, `UNSTABLE_BUT_FAST`, or `STABLE_BUT_SLOW`.
 """
 @enum ParamsSetting DEFAULT UNSTABLE_BUT_FAST STABLE_BUT_SLOW
 
-const DEPS_DIR = @get_scratch!(string("build_julia_", VERSION, "_", Sys.KERNEL))
+const DEPS_DIR = @get_scratch!(string("build_julia_", VERSION.major, ".", VERSION.minor, "_", Sys.KERNEL))
 
 if !isfile(joinpath(DEPS_DIR, "deps.jl"))
     error("""Build file not found. Please run `using Pkg; Pkg.build("SDPAFamily")` and

--- a/src/SDPAFamily.jl
+++ b/src/SDPAFamily.jl
@@ -24,6 +24,12 @@ Options are `DEFAULT`, `UNSTABLE_BUT_FAST`, or `STABLE_BUT_SLOW`.
 """
 @enum ParamsSetting DEFAULT UNSTABLE_BUT_FAST STABLE_BUT_SLOW
 
+const DEPS_DIR = @get_scratch!(string("build_julia_", VERSION, "_", Sys.KERNEL))
+
+if !isfile(joinpath(DEPS_DIR, "deps.jl"))
+    error("""Build file not found. Please run `using Pkg; Pkg.build("SDPAFamily")` and
+             try loading the package again.""")
+end
 
 # The `deps.jl` file defines `HAS_WSL::Bool` and `sdpa_gmp::String`.
 #
@@ -33,9 +39,9 @@ Options are `DEFAULT`, `UNSTABLE_BUT_FAST`, or `STABLE_BUT_SLOW`.
 # in the binary call, we turn the paths into WSL paths.
 #
 # `sdpa_gmp` is the default path to the binary.
-include(joinpath(@__DIR__, "..", "deps", "deps.jl"))
+include(joinpath(DEPS_DIR, "deps.jl"))
 
-const prefix = Prefix(joinpath(@__DIR__, "..", "deps", "usr"))
+const prefix = Prefix(joinpath(DEPS_DIR, "usr"))
 
 function __init__()
     check_deps()

--- a/src/SDPAFamily.jl
+++ b/src/SDPAFamily.jl
@@ -6,6 +6,7 @@ using MathOptInterface
 const MOI = MathOptInterface
 const MOIB = MOI.Bridges
 using BinaryProvider
+using Scratch
 
 """
 Possible verbosity levels of an `SDPAFamily.Optimizer`.


### PR DESCRIPTION
Someone sent me error logs once where it looked like somehow they didn't have write permission to the default place temporary directories are. I think a scratch space is probably a better place to put these.

closes https://github.com/ericphanson/SDPAFamily.jl/issues/37